### PR TITLE
Proposed fix for RefOS compile issue

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -47,6 +47,7 @@
     <project name="refos.git" path="projects/refos">
         <!-- symlinks to make the project structure fit the build system -->
         <linkfile src="impl/Makefile" dest="Makefile"/>
+        <linkfile src="impl/Kbuild" dest="Kbuild"/>
         <linkfile src="impl/Kconfig" dest="Kconfig"/>
         <linkfile src="impl/configs" dest="configs"/>
         <linkfile src="impl/apps" dest="apps"/>


### PR DESCRIPTION
This PR is one of three. The PRs together should represent one possible way to fix the RefOS compile issue: seL4/refos-manifest#1

It involves the following 3 repos: refos-manifest, refos, libmuslc
